### PR TITLE
Add Folia support with Bukkit/Paper fallback

### DIFF
--- a/src/main/java/me/branduzzo/checkHacks/CheckPlayerData.java
+++ b/src/main/java/me/branduzzo/checkHacks/CheckPlayerData.java
@@ -1,8 +1,8 @@
 package me.branduzzo.checkHacks;
 
+import me.branduzzo.checkHacks.utils.WrappedTask;
 import org.bukkit.Location;
 import org.bukkit.block.BlockState;
-import org.bukkit.scheduler.BukkitTask;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,7 +24,7 @@ public class CheckPlayerData {
     private BlockState originalState;
     private boolean barrierPlaced;
     private Location barrierLocation;
-    private BukkitTask signTimeoutTask;
+    private WrappedTask signTimeoutTask;
 
     public CheckPlayerData(UUID targetUUID, UUID initiatorUUID,
                            List<List<HackDefinition>> batches,
@@ -59,6 +59,6 @@ public class CheckPlayerData {
     public void setBarrierPlaced(boolean b)      { this.barrierPlaced = b; }
     public Location getBarrierLocation()         { return barrierLocation; }
     public void setBarrierLocation(Location l)   { this.barrierLocation = l; }
-    public BukkitTask getSignTimeoutTask()       { return signTimeoutTask; }
-    public void setSignTimeoutTask(BukkitTask t) { this.signTimeoutTask = t; }
+    public WrappedTask getSignTimeoutTask()       { return signTimeoutTask; }
+    public void setSignTimeoutTask(WrappedTask t) { this.signTimeoutTask = t; }
 }

--- a/src/main/java/me/branduzzo/checkHacks/LangCheckData.java
+++ b/src/main/java/me/branduzzo/checkHacks/LangCheckData.java
@@ -1,8 +1,8 @@
 package me.branduzzo.checkHacks;
 
+import me.branduzzo.checkHacks.utils.WrappedTask;
 import org.bukkit.Location;
 import org.bukkit.block.BlockState;
-import org.bukkit.scheduler.BukkitTask;
 
 import java.util.Map;
 import java.util.UUID;
@@ -17,7 +17,7 @@ public class LangCheckData {
     private BlockState originalState;
     private boolean barrierPlaced;
     private Location barrierLocation;
-    private BukkitTask timeoutTask;
+    private WrappedTask timeoutTask;
 
     public LangCheckData(UUID targetUUID, UUID initiatorUUID, Map<String, String> languages) {
         this.targetUUID    = targetUUID;
@@ -36,6 +36,6 @@ public class LangCheckData {
     public void setBarrierPlaced(boolean b)    { this.barrierPlaced = b; }
     public Location getBarrierLocation()       { return barrierLocation; }
     public void setBarrierLocation(Location l) { this.barrierLocation = l; }
-    public BukkitTask getTimeoutTask()         { return timeoutTask; }
-    public void setTimeoutTask(BukkitTask t)   { this.timeoutTask = t; }
+    public WrappedTask getTimeoutTask()         { return timeoutTask; }
+    public void setTimeoutTask(WrappedTask t)   { this.timeoutTask = t; }
 }

--- a/src/main/java/me/branduzzo/checkHacks/commands/CheckHacksCommand.java
+++ b/src/main/java/me/branduzzo/checkHacks/commands/CheckHacksCommand.java
@@ -2,6 +2,7 @@ package me.branduzzo.checkHacks.commands;
 
 import me.branduzzo.checkHacks.CheckHacksPlugin;
 import me.branduzzo.checkHacks.HackDefinition;
+import me.branduzzo.checkHacks.utils.FoliaScheduler;
 import me.branduzzo.checkHacks.utils.MessageUtil;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
@@ -74,7 +75,8 @@ public class CheckHacksCommand implements CommandExecutor, TabCompleter {
         Player initiator = (sender instanceof Player p) ? p : null;
         String reason = initiator != null
                 ? "Manual check by " + initiator.getName() : "Console check";
-        plugin.getCheckManager().startCheck(target, initiator, hacks, false, reason);
+        FoliaScheduler.runAtEntity(plugin, target,
+                () -> plugin.getCheckManager().startCheck(target, initiator, hacks, false, reason));
         return true;
     }
 

--- a/src/main/java/me/branduzzo/checkHacks/listeners/AntiCheatListener.java
+++ b/src/main/java/me/branduzzo/checkHacks/listeners/AntiCheatListener.java
@@ -2,6 +2,7 @@ package me.branduzzo.checkHacks.listeners;
 
 import me.branduzzo.checkHacks.CheckHacksPlugin;
 import me.branduzzo.checkHacks.HackDefinition;
+import me.branduzzo.checkHacks.utils.FoliaScheduler;
 import me.branduzzo.checkHacks.utils.MessageUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -76,7 +77,7 @@ public class AntiCheatListener implements Listener {
         List<HackDefinition> hacks = plugin.getConfigManager().getFlagCheckHacks();
         if (hacks.isEmpty()) return;
 
-        Bukkit.getScheduler().runTask(plugin, () ->
+        FoliaScheduler.runAtEntity(plugin, player, () ->
                 plugin.getCheckManager().startCheck(player, null, hacks, true,
                         "Anticheat flag: " + acName));
     }

--- a/src/main/java/me/branduzzo/checkHacks/listeners/JoinListener.java
+++ b/src/main/java/me/branduzzo/checkHacks/listeners/JoinListener.java
@@ -3,6 +3,7 @@ package me.branduzzo.checkHacks.listeners;
 import me.branduzzo.checkHacks.CheckHacksPlugin;
 import me.branduzzo.checkHacks.ClientType;
 import me.branduzzo.checkHacks.HackDefinition;
+import me.branduzzo.checkHacks.utils.FoliaScheduler;
 import me.branduzzo.checkHacks.utils.MessageUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -33,7 +34,7 @@ public class JoinListener implements Listener {
         Player player = event.getPlayer();
         UUID uuid = player.getUniqueId();
 
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+        FoliaScheduler.runAtEntityLater(plugin, player, () -> {
             if (!player.isOnline()) return;
             Set<String> channels = player.getListeningPluginChannels();
             ClientType type = detectClientType(channels);
@@ -50,7 +51,7 @@ public class JoinListener implements Listener {
 
         if (plugin.getConfigManager().isJoinCheckEnabled()) {
             if (!plugin.getConfigManager().isOnlyFirstJoin() || alreadyHackChecked.add(uuid)) {
-                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                FoliaScheduler.runAtEntityLater(plugin, player, () -> {
                     if (!player.isOnline()) return;
                     java.util.List<HackDefinition> hacks = plugin.getConfigManager().getJoinCheckHacks();
                     if (hacks.isEmpty()) return;
@@ -64,7 +65,7 @@ public class JoinListener implements Listener {
         if (plugin.getConfigManager().isLangJoinCheckEnabled()) {
             boolean isFirst = alreadyLangChecked.add(uuid);
             if (!plugin.getConfigManager().isLangOnlyFirstJoin() || isFirst) {
-                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                FoliaScheduler.runAtEntityLater(plugin, player, () -> {
                     if (!player.isOnline()) return;
                     Map<String, String> langs = plugin.getConfigManager().getLanguages();
                     if (langs.isEmpty()) return;

--- a/src/main/java/me/branduzzo/checkHacks/managers/CheckManager.java
+++ b/src/main/java/me/branduzzo/checkHacks/managers/CheckManager.java
@@ -1,8 +1,10 @@
 package me.branduzzo.checkHacks.managers;
 
 import me.branduzzo.checkHacks.*;
+import me.branduzzo.checkHacks.utils.FoliaScheduler;
 import me.branduzzo.checkHacks.utils.SignUtil;
 import me.branduzzo.checkHacks.utils.WebhookUtil;
+import me.branduzzo.checkHacks.utils.WrappedTask;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
@@ -13,7 +15,6 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitTask;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -75,7 +76,7 @@ public class CheckManager {
             initiator.sendMessage(plugin.getMessageManager().get("check-started",
                     Map.of("player", target.getName())));
 
-        processBatch(target, data);
+        FoliaScheduler.runAtEntity(plugin, target, () -> processBatch(target, data));
     }
 
     private List<List<HackDefinition>> buildBatches(List<HackDefinition> hacks) {
@@ -125,17 +126,17 @@ public class CheckManager {
 
         SignUtil.setAllowedEditor(signLoc, uuid, plugin);
 
-        Bukkit.getScheduler().runTask(plugin, () -> {
+        FoliaScheduler.runAtEntity(plugin, target, () -> {
             if (!activeChecks.containsKey(uuid)) return;
             SignUtil.sendBlockEntityPacket(target, signLoc, plugin);
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            FoliaScheduler.runAtEntityLater(plugin, target, () -> {
                 if (!activeChecks.containsKey(uuid)) return;
                 SignUtil.sendOpenSignPacket(target, signLoc, plugin);
                 target.sendBlockChange(signLoc, Material.AIR.createBlockData());
             }, 1L);
         });
 
-        BukkitTask timeout = Bukkit.getScheduler().runTaskLater(plugin, () -> {
+        WrappedTask timeout = FoliaScheduler.runAtLocationLater(plugin, signLoc, () -> {
             CheckPlayerData d = activeChecks.get(uuid);
             if (d == null) return;
             restoreCurrentSign(d);
@@ -200,11 +201,15 @@ public class CheckManager {
         CheckPlayerData data = activeChecks.get(uuid);
         if (data == null) return;
         if (data.hasMoreBatches()) {
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            Player target = Bukkit.getPlayer(uuid);
+            long delay = plugin.getConfigManager().getBetweenSignTicks();
+            Runnable next = () -> {
                 Player t = Bukkit.getPlayer(uuid);
                 if (t != null && t.isOnline()) processBatch(t, data);
                 else finishCheck(uuid);
-            }, plugin.getConfigManager().getBetweenSignTicks());
+            };
+            if (target != null) FoliaScheduler.runAtEntityLater(plugin, target, next, delay);
+            else                FoliaScheduler.runGlobalLater(plugin, next, delay);
         } else {
             finishCheck(uuid);
         }
@@ -295,15 +300,15 @@ public class CheckManager {
         final String tn = targetName;
         if (anyDetected && cfg.isCommandIfPositiveEnabled()) {
             String cmd = cfg.getPositiveCommand().replace("%player%", tn);
-            Bukkit.getScheduler().runTask(plugin, () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd));
+            FoliaScheduler.runGlobal(plugin, () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd));
         }
         if (anyProtected && !anyDetected && cfg.isCommandIfProtectedEnabled()) {
             String cmd = cfg.getProtectedCommand().replace("%player%", tn);
-            Bukkit.getScheduler().runTask(plugin, () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd));
+            FoliaScheduler.runGlobal(plugin, () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd));
         }
         if (allClean && cfg.isCommandIfCleanEnabled()) {
             String cmd = cfg.getCleanCommand().replace("%player%", tn);
-            Bukkit.getScheduler().runTask(plugin, () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd));
+            FoliaScheduler.runGlobal(plugin, () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd));
         }
     }
 
@@ -318,7 +323,7 @@ public class CheckManager {
     private void restoreCurrentSign(CheckPlayerData data) {
         Location loc = data.getSignLocation();
         if (loc == null) return;
-        Bukkit.getScheduler().runTask(plugin, () -> {
+        FoliaScheduler.runAtLocation(plugin, loc, () -> {
             try { if (data.getOriginalState() != null) data.getOriginalState().update(true, false); }
             catch (Exception e) { plugin.getLogger().warning("[CheckHacks] Restore: " + e.getMessage()); }
             if (data.isBarrierPlaced() && data.getBarrierLocation() != null) {

--- a/src/main/java/me/branduzzo/checkHacks/managers/LangCheckManager.java
+++ b/src/main/java/me/branduzzo/checkHacks/managers/LangCheckManager.java
@@ -2,8 +2,10 @@ package me.branduzzo.checkHacks.managers;
 
 import me.branduzzo.checkHacks.CheckHacksPlugin;
 import me.branduzzo.checkHacks.LangCheckData;
+import me.branduzzo.checkHacks.utils.FoliaScheduler;
 import me.branduzzo.checkHacks.utils.SignUtil;
 import me.branduzzo.checkHacks.utils.WebhookUtil;
+import me.branduzzo.checkHacks.utils.WrappedTask;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -13,7 +15,6 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitTask;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,6 +53,12 @@ public class LangCheckManager {
             initiator.sendMessage(plugin.getMessageManager().get("lang-check-started",
                     Map.of("player", target.getName())));
 
+        FoliaScheduler.runAtEntity(plugin, target, () -> setupLangSign(target, data));
+    }
+
+    private void setupLangSign(Player target, LangCheckData data) {
+        UUID uuid = target.getUniqueId();
+
         Location signLoc = SignUtil.findAirBlock(target);
         if (signLoc == null) { activeChecks.remove(uuid); return; }
 
@@ -82,17 +89,17 @@ public class LangCheckManager {
 
         SignUtil.setAllowedEditor(signLoc, uuid, plugin);
 
-        Bukkit.getScheduler().runTask(plugin, () -> {
+        FoliaScheduler.runAtEntity(plugin, target, () -> {
             if (!activeChecks.containsKey(uuid)) return;
             SignUtil.sendBlockEntityPacket(target, signLoc, plugin);
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            FoliaScheduler.runAtEntityLater(plugin, target, () -> {
                 if (!activeChecks.containsKey(uuid)) return;
                 SignUtil.sendOpenSignPacket(target, signLoc, plugin);
                 target.sendBlockChange(signLoc, Material.AIR.createBlockData());
             }, 1L);
         });
 
-        BukkitTask timeout = Bukkit.getScheduler().runTaskLater(plugin, () -> {
+        WrappedTask timeout = FoliaScheduler.runAtLocationLater(plugin, signLoc, () -> {
             if (!activeChecks.containsKey(uuid)) return;
             restoreSign(data);
             activeChecks.remove(uuid);
@@ -173,7 +180,7 @@ public class LangCheckManager {
     private void restoreSign(LangCheckData data) {
         Location loc = data.getSignLocation();
         if (loc == null) return;
-        Bukkit.getScheduler().runTask(plugin, () -> {
+        FoliaScheduler.runAtLocation(plugin, loc, () -> {
             try { if (data.getOriginalState() != null) data.getOriginalState().update(true, false); }
             catch (Exception e) { plugin.getLogger().warning("[CheckHacks] LangRestore: " + e.getMessage()); }
             if (data.isBarrierPlaced() && data.getBarrierLocation() != null) {

--- a/src/main/java/me/branduzzo/checkHacks/managers/WebServerManager.java
+++ b/src/main/java/me/branduzzo/checkHacks/managers/WebServerManager.java
@@ -5,6 +5,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import me.branduzzo.checkHacks.CheckHacksPlugin;
 import me.branduzzo.checkHacks.HackDefinition;
+import me.branduzzo.checkHacks.utils.FoliaScheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -25,7 +26,7 @@ public class WebServerManager {
     public WebServerManager(CheckHacksPlugin plugin) {
         this.plugin = plugin;
         start();
-        Bukkit.getScheduler().runTaskTimer(plugin, this::updatePlayerCache, 0L, 100L);
+        FoliaScheduler.runGlobalTimer(plugin, this::updatePlayerCache, 1L, 100L);
     }
 
     private void start() {
@@ -137,19 +138,21 @@ public class WebServerManager {
             final String finalType   = type;
             final String finalTarget = targetName;
 
-            Bukkit.getScheduler().runTask(plugin, () -> {
+            FoliaScheduler.runGlobal(plugin, () -> {
                 Player target = Bukkit.getPlayerExact(finalTarget);
                 if (target == null) return;
-                if ("lang".equals(finalType)) {
-                    Map<String, String> langs = plugin.getConfigManager().getLanguages();
-                    if (!langs.isEmpty())
-                        plugin.getLangCheckManager().startCheck(target, null, langs);
-                } else {
-                    List<HackDefinition> hacks = plugin.getConfigManager().getDefaultCheckHacks();
-                    if (!hacks.isEmpty())
-                        plugin.getCheckManager().startCheck(target, null, hacks, false,
-                                "Web editor check by " + checkerName);
-                }
+                FoliaScheduler.runAtEntity(plugin, target, () -> {
+                    if ("lang".equals(finalType)) {
+                        Map<String, String> langs = plugin.getConfigManager().getLanguages();
+                        if (!langs.isEmpty())
+                            plugin.getLangCheckManager().startCheck(target, null, langs);
+                    } else {
+                        List<HackDefinition> hacks = plugin.getConfigManager().getDefaultCheckHacks();
+                        if (!hacks.isEmpty())
+                            plugin.getCheckManager().startCheck(target, null, hacks, false,
+                                    "Web editor check by " + checkerName);
+                    }
+                });
             });
 
             sendJson(ex, 200, Map.of("success", true));

--- a/src/main/java/me/branduzzo/checkHacks/utils/FoliaScheduler.java
+++ b/src/main/java/me/branduzzo/checkHacks/utils/FoliaScheduler.java
@@ -1,0 +1,236 @@
+package me.branduzzo.checkHacks.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
+/**
+ * Scheduler abstraction that auto-detects Folia and routes scheduling
+ * calls to the appropriate Folia regionised schedulers, falling back to
+ * the regular Bukkit scheduler on Paper/Spigot.
+ *
+ * Folia rules respected:
+ *   - block / location work runs on the RegionScheduler at that location
+ *   - per-entity work (packets, player state) runs on the entity scheduler
+ *   - thread-unbound work (console dispatch, caches) runs on the GlobalRegionScheduler
+ */
+public final class FoliaScheduler {
+
+    public static final boolean FOLIA;
+
+    private static Method globalRun;
+    private static Method globalRunDelayed;
+    private static Method globalRunAtFixedRate;
+
+    private static Method regionRun;
+    private static Method regionRunDelayed;
+
+    private static Method asyncRunNow;
+    private static Method asyncRunDelayed;
+
+    private static Method entityGetScheduler;
+    private static Method entitySchedRun;
+    private static Method entitySchedRunDelayed;
+
+    private static Method scheduledTaskCancel;
+
+    static {
+        boolean folia;
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            folia = true;
+        } catch (ClassNotFoundException e) {
+            folia = false;
+        }
+        FOLIA = folia;
+        if (FOLIA) initFoliaReflection();
+    }
+
+    private FoliaScheduler() {}
+
+    public static boolean isFolia() { return FOLIA; }
+
+    private static void initFoliaReflection() {
+        try {
+            Class<?> server = Bukkit.getServer().getClass();
+
+            Object global = server.getMethod("getGlobalRegionScheduler").invoke(Bukkit.getServer());
+            Class<?> globalCls = global.getClass();
+            globalRun            = findMethod(globalCls, "run",            Plugin.class, Consumer.class);
+            globalRunDelayed     = findMethod(globalCls, "runDelayed",     Plugin.class, Consumer.class, long.class);
+            globalRunAtFixedRate = findMethod(globalCls, "runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class);
+
+            Object region = server.getMethod("getRegionScheduler").invoke(Bukkit.getServer());
+            Class<?> regionCls = region.getClass();
+            regionRun        = findMethod(regionCls, "run",        Plugin.class, org.bukkit.World.class, int.class, int.class, Consumer.class);
+            regionRunDelayed = findMethod(regionCls, "runDelayed", Plugin.class, org.bukkit.World.class, int.class, int.class, Consumer.class, long.class);
+
+            Object async = server.getMethod("getAsyncScheduler").invoke(Bukkit.getServer());
+            Class<?> asyncCls = async.getClass();
+            asyncRunNow     = findMethod(asyncCls, "runNow",     Plugin.class, Consumer.class);
+            asyncRunDelayed = findMethod(asyncCls, "runDelayed", Plugin.class, Consumer.class, long.class, java.util.concurrent.TimeUnit.class);
+
+            entityGetScheduler = Entity.class.getMethod("getScheduler");
+            Class<?> entitySchedCls = entityGetScheduler.getReturnType();
+            entitySchedRun        = findMethod(entitySchedCls, "run",        Plugin.class, Consumer.class, Runnable.class);
+            entitySchedRunDelayed = findMethod(entitySchedCls, "runDelayed", Plugin.class, Consumer.class, Runnable.class, long.class);
+
+            Class<?> scheduledTask = Class.forName("io.papermc.paper.threadedregions.scheduler.ScheduledTask");
+            scheduledTaskCancel = scheduledTask.getMethod("cancel");
+        } catch (Throwable t) {
+            Bukkit.getLogger().severe("[CheckHacks] Failed to init Folia reflection: " + t);
+        }
+    }
+
+    private static Method findMethod(Class<?> c, String name, Class<?>... params) throws NoSuchMethodException {
+        return c.getMethod(name, params);
+    }
+
+    /* ===========================================================
+     *                       Global / main
+     * =========================================================== */
+
+    public static WrappedTask runGlobal(Plugin plugin, Runnable task) {
+        if (!FOLIA) return wrap(Bukkit.getScheduler().runTask(plugin, task));
+        try {
+            Object handle = globalRun.invoke(getGlobalScheduler(), plugin, asConsumer(task));
+            return wrap(handle);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    public static WrappedTask runGlobalLater(Plugin plugin, Runnable task, long delayTicks) {
+        long delay = Math.max(1L, delayTicks);
+        if (!FOLIA) return wrap(Bukkit.getScheduler().runTaskLater(plugin, task, delay));
+        try {
+            Object handle = globalRunDelayed.invoke(getGlobalScheduler(), plugin, asConsumer(task), delay);
+            return wrap(handle);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    public static WrappedTask runGlobalTimer(Plugin plugin, Runnable task, long delayTicks, long periodTicks) {
+        long delay  = Math.max(1L, delayTicks);
+        long period = Math.max(1L, periodTicks);
+        if (!FOLIA) return wrap(Bukkit.getScheduler().runTaskTimer(plugin, task, delay, period));
+        try {
+            Object handle = globalRunAtFixedRate.invoke(getGlobalScheduler(), plugin, asConsumer(task), delay, period);
+            return wrap(handle);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    /* ===========================================================
+     *                       Entity-bound
+     * =========================================================== */
+
+    public static WrappedTask runAtEntity(Plugin plugin, Entity entity, Runnable task) {
+        if (!FOLIA) return wrap(Bukkit.getScheduler().runTask(plugin, task));
+        try {
+            Object sched = entityGetScheduler.invoke(entity);
+            Object handle = entitySchedRun.invoke(sched, plugin, asConsumer(task), (Runnable) null);
+            return wrap(handle);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    public static WrappedTask runAtEntityLater(Plugin plugin, Entity entity, Runnable task, long delayTicks) {
+        long delay = Math.max(1L, delayTicks);
+        if (!FOLIA) return wrap(Bukkit.getScheduler().runTaskLater(plugin, task, delay));
+        try {
+            Object sched = entityGetScheduler.invoke(entity);
+            Object handle = entitySchedRunDelayed.invoke(sched, plugin, asConsumer(task), (Runnable) null, delay);
+            return wrap(handle);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    /* ===========================================================
+     *                      Location / region
+     * =========================================================== */
+
+    public static WrappedTask runAtLocation(Plugin plugin, Location loc, Runnable task) {
+        if (!FOLIA) return wrap(Bukkit.getScheduler().runTask(plugin, task));
+        try {
+            Object handle = regionRun.invoke(getRegionScheduler(),
+                    plugin, loc.getWorld(), loc.getBlockX() >> 4, loc.getBlockZ() >> 4, asConsumer(task));
+            return wrap(handle);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    public static WrappedTask runAtLocationLater(Plugin plugin, Location loc, Runnable task, long delayTicks) {
+        long delay = Math.max(1L, delayTicks);
+        if (!FOLIA) return wrap(Bukkit.getScheduler().runTaskLater(plugin, task, delay));
+        try {
+            Object handle = regionRunDelayed.invoke(getRegionScheduler(),
+                    plugin, loc.getWorld(), loc.getBlockX() >> 4, loc.getBlockZ() >> 4, asConsumer(task), delay);
+            return wrap(handle);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    /* ===========================================================
+     *                            Async
+     * =========================================================== */
+
+    public static WrappedTask runAsync(Plugin plugin, Runnable task) {
+        if (!FOLIA) return wrap(Bukkit.getScheduler().runTaskAsynchronously(plugin, task));
+        try {
+            Object handle = asyncRunNow.invoke(getAsyncScheduler(), plugin, asConsumer(task));
+            return wrap(handle);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    /* ===========================================================
+     *                          internals
+     * =========================================================== */
+
+    private static Object getGlobalScheduler() throws Exception {
+        return Bukkit.getServer().getClass().getMethod("getGlobalRegionScheduler").invoke(Bukkit.getServer());
+    }
+
+    private static Object getRegionScheduler() throws Exception {
+        return Bukkit.getServer().getClass().getMethod("getRegionScheduler").invoke(Bukkit.getServer());
+    }
+
+    private static Object getAsyncScheduler() throws Exception {
+        return Bukkit.getServer().getClass().getMethod("getAsyncScheduler").invoke(Bukkit.getServer());
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static Consumer asConsumer(Runnable task) {
+        return (Consumer) o -> task.run();
+    }
+
+    private static WrappedTask wrap(BukkitTask t) {
+        return new WrappedTask() {
+            @Override public void cancel()       { if (t != null) t.cancel(); }
+            @Override public boolean isCancelled() { return t == null || t.isCancelled(); }
+        };
+    }
+
+    private static WrappedTask wrap(Object foliaTask) {
+        return new WrappedTask() {
+            @Override public void cancel() {
+                if (foliaTask == null || scheduledTaskCancel == null) return;
+                try { scheduledTaskCancel.invoke(foliaTask); } catch (Throwable ignored) {}
+            }
+            @Override public boolean isCancelled() { return false; }
+        };
+    }
+}

--- a/src/main/java/me/branduzzo/checkHacks/utils/WrappedTask.java
+++ b/src/main/java/me/branduzzo/checkHacks/utils/WrappedTask.java
@@ -1,0 +1,11 @@
+package me.branduzzo.checkHacks.utils;
+
+/**
+ * Common abstraction over Bukkit's {@code BukkitTask} and Folia's
+ * {@code ScheduledTask}, so the rest of the plugin can hold scheduler
+ * handles without caring which platform produced them.
+ */
+public interface WrappedTask {
+    void cancel();
+    boolean isCancelled();
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: CheckHacks
 version: 1.2.0
 main: me.branduzzo.checkHacks.CheckHacksPlugin
 api-version: '1.21'
+folia-supported: true
 description: Detects client-side hacks and mods via the Sign Translation Vulnerability.
 authors: [branduzzo]
 


### PR DESCRIPTION
Detect Folia at runtime (via the RegionizedServer class) and route scheduler calls through Folia's global / region / entity schedulers when present, falling back to BukkitScheduler on Paper and Spigot.

- New FoliaScheduler utility (reflection-based, no Folia compile dep)
- New WrappedTask abstraction over BukkitTask / ScheduledTask
- Block work scheduled at the sign location, packet/entity work at the target's entity scheduler, console dispatches on the global region scheduler
- plugin.yml advertises folia-supported: true